### PR TITLE
Bugfix/header title space

### DIFF
--- a/src/home-page.html
+++ b/src/home-page.html
@@ -16,7 +16,7 @@
 
       <div class="title">
         <div class="title-line">
-          <span>Let's</span>
+          <span>Let's </span>
           <div class="title-animation">
             <span class="title-emphasis">design</span>
           </div>


### PR DESCRIPTION
Fixing space between words in the title:

![Screenshot 2021-01-06 at 15 37 20](https://user-images.githubusercontent.com/371041/103780301-1a51f680-5035-11eb-8cb4-4a6e25444d94.png)
